### PR TITLE
Decrypt empty check

### DIFF
--- a/src/middleware/EncryptCookies.php
+++ b/src/middleware/EncryptCookies.php
@@ -61,6 +61,10 @@ class EncryptCookies implements Middleware
 	 */
 	public function decrypt(FigCookies\Cookie $cookie): FigCookies\Cookie
 	{
+		if (!$cookie->getValue()) {
+			return $cookie->withValue('');
+		}
+		
 		try {
 			return $cookie->withValue(Crypto\Crypto::decrypt($cookie->getValue(), $this->key));
 		} catch (Exception $e) {


### PR DESCRIPTION
Updating decrypt to fallback to return an empty cookie.  This is necessary in some browsers to prevent a type error in the crypto library.